### PR TITLE
Refactor/move transaction details dialog

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import {
   WalletProvider
 } from "./context/walletProvider/walletProviderFacade";
 import { WrongChainProvider } from "./context/wrongChainContext";
+import { TransactionProvider } from "./context/transactionContext";
 import {
   ethChainId,
   fortmaticApiKey,
@@ -42,9 +43,11 @@ function App() {
           <UALProviderSwitch>
             <WalletProvider>
               <WrongChainProvider>
-                <Router>
-                  <Routes />
-                </Router>
+                <TransactionProvider>
+                  <Router>
+                    <Routes />
+                  </Router>
+                </TransactionProvider>
               </WrongChainProvider>
             </WalletProvider>
           </UALProviderSwitch>

--- a/src/components/layouts/layout.js
+++ b/src/components/layouts/layout.js
@@ -15,10 +15,13 @@ import { useTranslation } from "react-i18next";
 import { useWallet } from "use-wallet";
 
 import { WallerProviderContext as UALContext } from "../../context/walletProvider/walletProviderFacade";
+import { TransactionContext } from "../../context/transactionContext";
 import GlobalStyle from "../globalStyles";
 import LanguageSelector from "./LanguageMenu/LanguageSelector";
 import EthereumWalletModal from "../ui/ethereumWalletModal";
 import WrongChainModal from "../ui/wrongChainModal";
+import InfoAlert from "../ui/infoAlert";
+import TxDetailsDialog from "../ui/txDetailsDialog";
 
 const isWalletConnected = () => {
   const val = localStorage.getItem("__WALLET_CONNECTED");
@@ -33,11 +36,13 @@ const StyledButtonsRow = styled(Row)`
 const Layout = ({ children }) => {
   const location = useLocation();
   const authContext = useContext(UALContext);
+  const { txDone } = useContext(TransactionContext);
   const { t, i18n } = useTranslation();
   const LngUrl = `?lng=${i18n.language}`;
   const [ethModalShow, setEthModalShow] = useState(false);
   const connectedId = isWalletConnected();
   const wallet = useWallet();
+
   if (wallet.status === "disconnected" && connectedId != null) {
     wallet.connect(connectedId);
   }
@@ -169,7 +174,15 @@ const Layout = ({ children }) => {
         </Navbar.Collapse>
       </Navbar>
       {children}
+      {wallet.account && txDone && (
+        <Row>
+          <Col>
+            <InfoAlert text={t("tx_executed")} />
+          </Col>
+        </Row>
+      )}
       <WrongChainModal />
+      <TxDetailsDialog />
       <EthereumWalletModal
         show={ethModalShow}
         onHide={() => setEthModalShow(false)}

--- a/src/components/ui/txDetailsDialog.js
+++ b/src/components/ui/txDetailsDialog.js
@@ -1,19 +1,26 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React, { useContext } from "react";
 import { Modal, Button, Alert, ListGroup } from "react-bootstrap";
 import { Search } from "react-bootstrap-icons";
 import { useTranslation } from "react-i18next";
 
 import { ethBasedExplorerUrl } from "../../config";
+import { TransactionContext } from "../../context/transactionContext";
 
-const TxDetailsDialog = ({ hashes, ...props }) => {
+const TxDetailsDialog = () => {
   const { t } = useTranslation();
+  const { openTxDetails, setOpenTxDetails, hashes } =
+    useContext(TransactionContext);
 
   const chunkString = stringToChunk =>
     `${stringToChunk.match(/.{1,20}/g)[0]}...`;
 
   return (
-    <Modal {...props} size="sm" centered>
+    <Modal
+      show={openTxDetails}
+      onHide={() => setOpenTxDetails(false)}
+      size="sm"
+      centered
+    >
       <Modal.Header closeButton className="px-3 py-2">
         <Modal.Title className="font-weight-light">
           {t("transactions")}
@@ -51,10 +58,6 @@ const TxDetailsDialog = ({ hashes, ...props }) => {
       </Modal.Body>
     </Modal>
   );
-};
-
-TxDetailsDialog.propTypes = {
-  hashes: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default TxDetailsDialog;

--- a/src/context/transactionContext.js
+++ b/src/context/transactionContext.js
@@ -1,0 +1,49 @@
+import React, { createContext, useState } from "react";
+import PropTypes from "prop-types";
+
+export const TransactionContext = createContext({
+  openTxDetails: false,
+  setOpenTxDetails: () => {},
+  hashes: [],
+  setHashes: () => {},
+  txDone: false,
+  setTxDone: () => {}
+});
+
+export const TransactionProvider = ({ children }) => {
+  const setHashes = hashes => {
+    // eslint-disable-next-line no-use-before-define
+    setTxState({ ...txState, hashes });
+  };
+
+  const setOpenTxDetails = open => {
+    // eslint-disable-next-line no-use-before-define
+    setTxState({ ...txState, openTxDetails: open });
+  };
+
+  const setTxDone = done => {
+    // eslint-disable-next-line no-use-before-define
+    setTxState({ ...txState, txDone: done });
+  };
+
+  const initState = {
+    hashes: [],
+    setHashes,
+    openTxDetails: false,
+    setOpenTxDetails,
+    txDone: false,
+    setTxDone
+  };
+
+  const [txState, setTxState] = useState(initState);
+
+  return (
+    <TransactionContext.Provider value={txState}>
+      {children}
+    </TransactionContext.Provider>
+  );
+};
+
+TransactionProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};

--- a/src/features/Lock/lock.js
+++ b/src/features/Lock/lock.js
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useState } from "react";
+import React, { memo, useContext, useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import styled from "styled-components";
 import {
@@ -26,7 +26,7 @@ import {
   lockTokensTx
 } from "../../utils/EthDataProvider/EthDataProvider";
 import InfoSwapCard from "../../components/ui/infoSwapCard";
-import TxDetailsDialog from "../../components/ui/txDetailsDialog";
+import { TransactionContext } from "../../context/transactionContext";
 
 const HeaderText = styled.div`
   background-color: #f7f7f9;
@@ -47,15 +47,14 @@ const Lock = () => {
   const { t } = useTranslation();
   const methods = useForm({ mode: "onChange" });
   const wallet = useWallet();
-  const [txDone, setTxDone] = useState(false);
+  const { setHashes, setOpenTxDetails, setTxDone } =
+    useContext(TransactionContext);
   const [updatingBalance, setUpdatingBalance] = useState(false);
   const [loadingBalance, setLoadingBalance] = useState(false);
   const [balance, setBalance] = useState();
   const [lockValue, setLockValue] = useState(7);
   const [currentHiIQ, setCurrentHiIQ] = useState(undefined);
   const [filledAmount, setFilledAmount] = useState();
-  const [openTxDetailsDialog, setOpenTxDetailsDialog] = useState(true);
-  const [hashes, setHashes] = useState([]);
   const [token1] = useState({
     icon: "https://mindswap.finance/tokens/iq.png",
     name: "IQ",
@@ -80,7 +79,7 @@ const Lock = () => {
       );
     else setHashes(await lockTokensTx(data.FromAmount, lockValue, wallet));
 
-    setOpenTxDetailsDialog(true);
+    setOpenTxDetails(true);
 
     setUpdatingBalance(true);
 
@@ -183,13 +182,6 @@ const Lock = () => {
               )}
             </Col>
           </Row>
-          {wallet.account && txDone && (
-            <Row>
-              <Col>
-                <InfoAlert text={t("tx_executed")} />
-              </Col>
-            </Row>
-          )}
           {!wallet.account && (
             <Row>
               <Col>
@@ -199,14 +191,6 @@ const Lock = () => {
           )}
         </FormProvider>
       </Container>
-
-      {hashes.length >= 1 && (
-        <TxDetailsDialog
-          show={openTxDetailsDialog}
-          hashes={hashes}
-          onHide={() => setOpenTxDetailsDialog(false)}
-        />
-      )}
     </Layout>
   );
 };

--- a/src/features/Voting/voting.js
+++ b/src/features/Voting/voting.js
@@ -1,4 +1,4 @@
-import React, { memo, useState, useEffect } from "react";
+import React, { memo, useState, useEffect, useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { Card, Col, Container, Row, Button, Spinner } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
@@ -21,6 +21,7 @@ import VotingProposalForm from "./votingProposalForm";
 import VoteBreakdown from "../../components/ui/voteBreakdown";
 import GenericDialog from "../../components/ui/genericDialog";
 import ProposalDetails from "../../components/ui/proposalDetails";
+import { TransactionContext } from "../../context/transactionContext";
 
 const StyledCard = styled(Card)`
   min-height: 583px;
@@ -38,7 +39,7 @@ const Voting = () => {
   const { t } = useTranslation();
   const methods = useForm({ mode: "onChange" });
   const wallet = useWallet();
-  const [txDone, setTxDone] = useState(false);
+  const { setTxDone } = useContext(TransactionContext);
   const [proposals, setProposals] = useState();
   const [selectedProposal, setSelectedProposal] = useState();
   const [loadingSelectedProposal, setLoadingSelectedProposal] = useState(false);
@@ -272,13 +273,6 @@ const Voting = () => {
                 </StyledCard>
               </Col>
             </Row>
-            {wallet.account && txDone && (
-              <Row>
-                <Col>
-                  <InfoAlert text={t("confirmed_tx")} />
-                </Col>
-              </Row>
-            )}
             {!wallet.account && (
               <Row>
                 <Col>

--- a/src/features/eth.js
+++ b/src/features/eth.js
@@ -1,4 +1,4 @@
-import React, { useState, memo } from "react";
+import React, { useState, memo, useContext } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import styled from "styled-components";
 import { Button, Card, Col, Container, Form, Row } from "react-bootstrap";
@@ -6,12 +6,12 @@ import { ArrowDownShort } from "react-bootstrap-icons";
 import { useTranslation } from "react-i18next";
 import { useWallet } from "use-wallet";
 
-import TxDetailsDialog from "../components/ui/txDetailsDialog";
 import Layout from "../components/layouts/layout";
 import SwapContainer from "../components/ui/swapContainer";
 import CardTitle from "../components/ui/cardTitle";
 import InfoAlert from "../components/ui/infoAlert";
 import { convertPTokensTx } from "../utils/EthDataProvider/EthDataProvider";
+import { TransactionContext } from "../context/transactionContext";
 
 const IconWrapper = styled(Button)`
   margin: 15px;
@@ -28,9 +28,8 @@ const Eth = () => {
   const { t } = useTranslation();
   const methods = useForm({ mode: "onChange" });
   const wallet = useWallet();
-  const [txDone, setTxDone] = useState(false);
-  const [openTxDetailsDialog, setOpenTxDetailsDialog] = useState(true);
-  const [hashes, setHashes] = useState([]);
+  const { setHashes, setOpenTxDetails, setTxDone } =
+    useContext(TransactionContext);
   const [token1, setToken1] = useState({
     icon: "https://mindswap.finance/tokens/iq.png",
     name: "pIQ",
@@ -43,14 +42,11 @@ const Eth = () => {
       return;
     }
 
+    setOpenTxDetails(true);
+
     setHashes(await convertPTokensTx(data.FromAmount, wallet));
 
     setTxDone(true);
-  };
-
-  const handleOnDialogHide = () => {
-    setOpenTxDetailsDialog(false);
-    setHashes([]);
   };
 
   return (
@@ -89,20 +85,6 @@ const Eth = () => {
               </Card>
             </Col>
           </Row>
-          {hashes.length >= 1 && (
-            <TxDetailsDialog
-              show={openTxDetailsDialog}
-              hashes={hashes}
-              onHide={handleOnDialogHide}
-            />
-          )}
-          {wallet.account && txDone && (
-            <Row>
-              <Col>
-                <InfoAlert text={t("tx_executed")} />
-              </Col>
-            </Row>
-          )}
           {!wallet.account && (
             <Row>
               <Col>

--- a/src/features/reverseEth.js
+++ b/src/features/reverseEth.js
@@ -1,4 +1,4 @@
-import React, { memo, useState } from "react";
+import React, { memo, useContext, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import styled from "styled-components";
 import { Button, Card, Col, Container, Form, Row } from "react-bootstrap";
@@ -12,6 +12,7 @@ import CardTitle from "../components/ui/cardTitle";
 import InfoAlert from "../components/ui/infoAlert";
 import { reverseIQtoEOSTx } from "../utils/EthDataProvider/EthDataProvider";
 import AddressContainer from "../components/ui/addressContainer";
+import { TransactionContext } from "../context/transactionContext";
 
 // TODO: this is 3-4 times already, time to extract
 const IconWrapper = styled(Button)`
@@ -29,7 +30,7 @@ const ReverseEth = () => {
   const { t } = useTranslation();
   const methods = useForm({ mode: "onChange" });
   const wallet = useWallet();
-  const [txDone, setTxDone] = useState(false);
+  const { setTxDone } = useContext(TransactionContext);
   const [token1, setToken1] = useState({
     icon: "https://mindswap.finance/tokens/iq.png",
     name: "IQ",
@@ -86,13 +87,6 @@ const ReverseEth = () => {
               </Card>
             </Col>
           </Row>
-          {wallet.account && txDone && (
-            <Row>
-              <Col>
-                <InfoAlert text={t("transactions_broadcasted")} />
-              </Col>
-            </Row>
-          )}
           {!wallet.account && (
             <Row>
               <Col>


### PR DESCRIPTION
#Manage a global state for Transaction details related stuff
_The idea with this PR is to provide a global state for transaction details, such as: hashes, open/close flags_
## How should this be tested?
1. `yarn start`
## Notes or observations
_no observations for this PR_
## Linked issues
closes #00, closes #42 
