### PR TITLE
fix: avoid floats quantities, since the contract seems to not support…

### DIFF
--- a/src/features/Lock/lock.js
+++ b/src/features/Lock/lock.js
@@ -355,6 +355,7 @@ const Lock = () => {
                         !wallet.account ||
                         (!balance && radioValue === 1) ||
                         (balance === 0 && radioValue === 1) ||
+                        filledAmount < 1 ||
                         (!filledAmount &&
                           currentHiIQ !== 0 &&
                           radioValue === 1) ||

--- a/src/utils/EthDataProvider/EthDataProvider.js
+++ b/src/utils/EthDataProvider/EthDataProvider.js
@@ -250,7 +250,12 @@ const reverseIQtoEOSTx = async (amount, wallet, eosAccount) => {
 };
 
 const lockTokensTx = async (amount, time, wallet, handleConfirmation) => {
-  const amountParsed = ethers.utils.parseEther(amount).toString();
+  let intAmount = amount;
+  intAmount = Math.floor(Number(intAmount));
+  intAmount = intAmount.toString();
+
+  const amountParsed = ethers.utils.parseEther(intAmount).toString();
+
   const d = new Date();
   d.setDate(d.getDate() + time);
 
@@ -332,7 +337,11 @@ const getMaximumLockableTime = async (wallet, lockEnd) => {
 };
 
 const increaseAmount = async (amount, wallet, handleConfirmation) => {
-  const amountParsed = ethers.utils.parseEther(amount).toString();
+  let intAmount = amount;
+  intAmount = Math.floor(Number(intAmount));
+  intAmount = intAmount.toString();
+
+  const amountParsed = ethers.utils.parseEther(intAmount).toString();
 
   if (wallet.status === "connected") {
     const provider = new ethers.providers.Web3Provider(wallet.ethereum);


### PR DESCRIPTION
# PR title goes here
_Prevent users to send amounts with decimals, since the contract seems to be not handling them_
## How should this be tested?
1. Step one
2. Step two
3. ...
## Notes or observations
Number sent in a transaction: 1345226975449258200000000
Actual user balance: 1345226975449258183277191
Tx link: https://etherscan.io/address/0x1bf5457ecaa14ff63cc89efd560e251e814e16ba
## Linked issues
closes #121 