### PR TITLE
hide checkpoint when there are no tokens locked

### DIFF
--- a/src/features/Lock/stats.js
+++ b/src/features/Lock/stats.js
@@ -318,7 +318,8 @@ const Stats = ({ wallet, lockedAlready }) => {
                         </Button>
                       ) : null}
 
-                      {earnedRewards !== undefined &&
+                      {lockedAlready &&
+                      earnedRewards !== undefined &&
                       earnedRewards === 0 &&
                       wallet.status === "connected" ? (
                         <div className="d-flex flex-row justify-content-center align-items-center">


### PR DESCRIPTION
# Hide Checkpoint button when the user hasn't locked any tokens so far
_This will avoid $ lost in unnecessary transactions_
## How should this be tested?
1. `yarn start`
2. Login with an account that has no previous locked tokens
## Notes or observations
__
## Linked issues
closes #143
