### PR TITLE
fix: avoid negative numbers

### DIFF
--- a/src/components/ui/rewardsCalculatorDialog.js
+++ b/src/components/ui/rewardsCalculatorDialog.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Form } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
@@ -32,6 +32,8 @@ const RewardsCalculatorDialog = ({
   const [years, setYears] = useState();
   const [aprDividedByLockPeriod, setAprDividedByLockPeriod] = useState();
   const [expectedIQ, setExpectedIQ] = useState();
+  const lockedIQRef = useRef(null);
+  const yearsRef = useRef(null);
 
   const handleOnHide = () => {
     setYears();
@@ -62,6 +64,18 @@ const RewardsCalculatorDialog = ({
     }
   }, [inputIQ, years]);
 
+  const handleLockedIQInput = e => {
+    const value = Number(e.target.value);
+    if (value < 0) lockedIQRef.current.value = "";
+    else setInputIQ(value);
+  };
+
+  const handleYearsInput = e => {
+    const value = Number(e.target.value);
+    if (value < 0 || value > 4) yearsRef.current.value = "";
+    else setYears(value);
+  };
+
   return (
     <GenericDialog
       size="sm"
@@ -81,15 +95,19 @@ const RewardsCalculatorDialog = ({
           ) : null}
           <StyledFormControl
             type="number"
-            onChange={event => setInputIQ(event.target.value)}
+            ref={lockedIQRef}
+            min="0"
+            onChange={handleLockedIQInput}
             placeholder={t("locked_iq")}
             className="mb-2"
           />
           <StyledFormControl
             type="number"
+            min="0"
             max="4"
-            onChange={event => setYears(event.target.value)}
-            placeholder={t("years")}
+            ref={yearsRef}
+            onChange={handleYearsInput}
+            placeholder={`${t("years")} (4 years max)`}
           />
           {inputIQ && years && aprDividedByLockPeriod ? (
             <StyledDivContainer className="shadow-sm">

--- a/src/components/ui/statsCharts.js
+++ b/src/components/ui/statsCharts.js
@@ -66,7 +66,6 @@ const StatsCharts = () => {
   };
 
   const configureTopHoldersChart = data => {
-    console.log(data);
     setAddresses(Object.keys(data));
     setVolumeChartData({
       labels: Object.keys(data).map(

--- a/src/features/Lock/stats.js
+++ b/src/features/Lock/stats.js
@@ -95,8 +95,6 @@ const Stats = ({ wallet, lockedAlready }) => {
     hiIQSupply,
     rewardsAcrossLockPeriod
   ) => {
-    // const rewards = await earned(wallet);
-
     const yearsLock = 4; // assuming a 4 year lock
 
     const amountLocked = lockedByUser > 0 ? lockedByUser : 100000;


### PR DESCRIPTION
# Avoid input negative numbers in the rewards calculator
_Avoid negative numbers input and restrict the years input to a max of 4 years_
## How should this be tested?
1. `yarn start`
## Notes or observations
_no observations_
## Linked issues
closes #00, closes #136 
