### PR TITLE
fix: infocard-not-showing-increasing-amount

### DIFF
--- a/src/components/ui/infoSwapCard.js
+++ b/src/components/ui/infoSwapCard.js
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 import { Card } from "react-bootstrap";
 import PropTypes from "prop-types";
-import { useTranslation } from "react-i18next";
 
 const SubCard = styled(Card)`
   max-width: 400px;
@@ -40,20 +39,23 @@ const SwapInfo = styled.div`
   }
 `;
 
-const InfoSwapCard = ({ timeLocked, tokensLocked }) => {
-  const { t } = useTranslation();
-
+const InfoSwapCard = ({
+  timeLockedDescription,
+  balanceDescription,
+  timeLocked,
+  tokensLocked
+}) => {
   return (
     <SubCard className="mx-auto shadow-sm rounded-bottom">
       <Card.Body>
         <SwapInfo>
           <div className="infoLine">
-            <div>{t("time_locked")}</div>
+            <div>{timeLockedDescription}</div>
             <div className="font-weight-bold">{timeLocked}</div>
           </div>
           <StyledDivider />
           <div className="infoLine">
-            <div>{t("new_hiiq_balance")}</div>
+            <div>{balanceDescription}</div>
             <div>
               <strong>
                 {Number(
@@ -70,6 +72,8 @@ const InfoSwapCard = ({ timeLocked, tokensLocked }) => {
 };
 
 InfoSwapCard.propTypes = {
+  timeLockedDescription: PropTypes.string.isRequired,
+  balanceDescription: PropTypes.string.isRequired,
   timeLocked: PropTypes.number.isRequired,
   tokensLocked: PropTypes.number.isRequired
 };

--- a/src/components/ui/swapContainer.js
+++ b/src/components/ui/swapContainer.js
@@ -181,12 +181,17 @@ const SwapContainer = ({
     if (Number.isNaN(value) || value < 0 || value > balToken) {
       setIsValidInput(false);
       setFilled(undefined);
+      setParentBalance(undefined);
       return;
     }
 
     setIsValidInput(true);
 
-    if (value === 0) return;
+    if (value === 0) {
+      setFilled(undefined);
+      setParentBalance(undefined);
+      return;
+    }
 
     setFilled(value);
   };

--- a/src/features/Lock/lock.js
+++ b/src/features/Lock/lock.js
@@ -108,6 +108,7 @@ const Lock = () => {
   const [lockedIQ, setLockedIQ] = useState(undefined);
   const [filledAmount, setFilledAmount] = useState();
   const [lockEnd, setLockEnd] = useState();
+  const [diffDays, setDiffDays] = useState();
   const [maximumLockableTime, setMaximumLockableTime] = useState();
   const [expired, setExpired] = useState();
   const [radioValue, setRadioValue] = useState(1);
@@ -239,6 +240,15 @@ const Lock = () => {
         setUpdatingBalance(false);
       })();
   }, [wallet.status, loadBalance]);
+
+  useEffect(() => {
+    if (filledAmount) {
+      const days = Number(
+        (lockEnd.getTime() - new Date().getTime()) / (1000 * 3600 * 24)
+      ).toFixed();
+      setDiffDays(days);
+    }
+  }, [filledAmount, lockEnd]);
 
   return (
     <Layout>
@@ -426,6 +436,8 @@ const Lock = () => {
               balance &&
               balance !== 0 ? (
                 <InfoSwapCard
+                  timeLockedDescription={t("time_locked")}
+                  balanceDescription={t("new_hiiq_balance")}
                   tokensLocked={Number(filledAmount)}
                   timeLocked={
                     currentHiIQ && lockEnd > 0
@@ -435,8 +447,19 @@ const Lock = () => {
                 />
               ) : null}
 
+              {lockEnd && filledAmount && diffDays ? (
+                <InfoSwapCard
+                  timeLockedDescription="Current unlock time (days)"
+                  balanceDescription="Expected hiIQ (includes current)"
+                  tokensLocked={Number(currentHiIQ) + Number(filledAmount)}
+                  timeLocked={Number(diffDays)}
+                />
+              ) : null}
+
               {lockValue && lockValue !== 0 && radioValue === 2 ? (
                 <InfoSwapCard
+                  timeLockedDescription={t("time_locked")}
+                  balanceDescription={t("new_hiiq_balance")}
                   tokensLocked={Number(currentHiIQ)}
                   timeLocked={Number(lockValue)}
                 />

--- a/src/features/Lock/lock.js
+++ b/src/features/Lock/lock.js
@@ -447,11 +447,11 @@ const Lock = () => {
                 />
               ) : null}
 
-              {lockEnd && filledAmount && diffDays ? (
+              {lockEnd && filledAmount && diffDays && lockedIQ ? (
                 <InfoSwapCard
                   timeLockedDescription="Current unlock time (days)"
                   balanceDescription="Expected hiIQ (includes current)"
-                  tokensLocked={Number(currentHiIQ) + Number(filledAmount)}
+                  tokensLocked={Number(lockedIQ) + Number(filledAmount)}
                   timeLocked={Number(diffDays)}
                 />
               ) : null}


### PR DESCRIPTION
# PR title goes here
_Info card data now includes current + new input iq amount, when increasing it_
## How should this be tested?
1. `yarn start`
## Notes or observations
_jot down something here_
## Linked issues
closes #146