### PR TITLE
fix: show checkpoint button if the user is not initialized

### DIFF
--- a/src/features/Lock/stats.js
+++ b/src/features/Lock/stats.js
@@ -21,7 +21,8 @@ import {
   earned,
   getStats,
   getYield,
-  defaultStats
+  defaultStats,
+  checkIfUserIsInitialized
 } from "../../utils/EthDataProvider/EthDataProvider";
 import CardTitle from "../../components/ui/cardTitle";
 import StatsCharts from "../../components/ui/statsCharts";
@@ -42,6 +43,7 @@ const Stats = ({ wallet, lockedAlready }) => {
   const [countdown, setCountdown] = useState(Date.now() + 25000);
   const [isCallingCheckpoint, setIsCallingCheckpoint] = useState(false);
   const [openRewardsCalculator, setOpenRewardsCalculator] = useState(false);
+  const [userIsInitialized, setUserIsInitialzed] = useState(undefined);
   const target = useRef(null);
   const checkpointOverlayTarget = useRef(null);
   const countDownComponentRef = useRef(null);
@@ -168,6 +170,8 @@ const Stats = ({ wallet, lockedAlready }) => {
   useEffect(() => {
     (async () => {
       if (wallet && wallet.status === "connected") {
+        setUserIsInitialzed(await checkIfUserIsInitialized(wallet));
+
         const rewards = await earned(wallet);
 
         try {
@@ -334,10 +338,13 @@ const Stats = ({ wallet, lockedAlready }) => {
                         </Button>
                       ) : null}
 
-                      {lockedAlready &&
-                      earnedRewards !== undefined &&
-                      earnedRewards === 0 &&
-                      wallet.status === "connected" ? (
+                      {(lockedAlready &&
+                        earnedRewards !== undefined &&
+                        earnedRewards === 0 &&
+                        wallet.status === "connected") ||
+                      (userIsInitialized !== undefined &&
+                        userIsInitialized === false) ? (
+                        // eslint-disable-next-line react/jsx-indent
                         <div className="d-flex flex-row justify-content-center align-items-center">
                           <Button
                             onClick={handleCallCheckpoint}

--- a/src/utils/EthDataProvider/EthDataProvider.js
+++ b/src/utils/EthDataProvider/EthDataProvider.js
@@ -40,6 +40,20 @@ const addGasLimitBuffer = value =>
     .mul(ethers.BigNumber.from(10000 + 2000))
     .div(ethers.BigNumber.from(10000));
 
+const checkIfUserIsInitialized = async wallet => {
+  if (wallet.status === "connected") {
+    const provider = new ethers.providers.Web3Provider(wallet.ethereum);
+
+    const hiIQRewards = getHiIQRewardsContract(provider, true);
+
+    const result = await hiIQRewards.userIsInitialized(wallet.account);
+
+    return result;
+  }
+
+  return undefined;
+};
+
 const callCheckpoint = async wallet => {
   if (wallet.status === "connected") {
     const provider = new ethers.providers.Web3Provider(wallet.ethereum);
@@ -378,6 +392,7 @@ const increaseUnlockTime = async (wallet, unlockTime, handleConfirmation) => {
 };
 
 export {
+  checkIfUserIsInitialized,
   callCheckpoint,
   earned,
   getYield,


### PR DESCRIPTION
# Show checkpoint button if the user is not initialized in the rewards system
_If the user is not initialized in the rewards system (skipped the checkpoint signing request) show the checkpoint button_
## How should this be tested?
1. `yarn start`

## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/24
