### PR TITLE
fix: rewards calculator apr

### DIFF
--- a/src/components/ui/rewardsCalculatorDialog.js
+++ b/src/components/ui/rewardsCalculatorDialog.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import { Form, Button } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
+import * as Humanize from "humanize-plus";
 import styled from "styled-components";
 
 import GenericDialog from "./genericDialog";
@@ -97,7 +98,9 @@ const RewardsCalculatorDialog = ({
               <p className="mb-0 text-center text-uppercase">
                 {" "}
                 {t("supply")} <br />
-                <strong>{Number(hiIQSupply).toFixed(0)} hiiq</strong>
+                <strong>
+                  {Humanize.intComma(Number(hiIQSupply).toFixed(0))} hiiq
+                </strong>
               </p>
             </div>
           ) : null}

--- a/src/components/ui/rewardsCalculatorDialog.js
+++ b/src/components/ui/rewardsCalculatorDialog.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
-import { Form } from "react-bootstrap";
+import { Form, Button } from "react-bootstrap";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 
@@ -19,6 +19,10 @@ const StyledFormControl = styled(Form.Control)`
     box-shadow: none !important;
   }
   border-radius: 5px !important;
+`;
+
+const StyledButton = styled(Button)`
+  border: 1px dashed lightblue !important;
 `;
 
 const RewardsCalculatorDialog = ({
@@ -73,8 +77,9 @@ const RewardsCalculatorDialog = ({
     else setInputIQ(value);
   };
 
-  const handleYearsInput = e => {
-    const value = Number(e.target.value);
+  const handleYearsInput = value => {
+    yearsRef.current.value = value;
+
     if (value < 0 || value > 4) yearsRef.current.value = "";
     else setYears(value);
   };
@@ -109,23 +114,55 @@ const RewardsCalculatorDialog = ({
             min="0"
             max="4"
             ref={yearsRef}
-            onChange={handleYearsInput}
+            onChange={event => handleYearsInput(Number(event.target.value))}
             placeholder={`${t("years")} (4 years max)`}
           />
-          {inputIQ && years && aprDividedByLockPeriod ? (
-            <StyledDivContainer className="shadow-sm">
-              <p className="mb-0">
-                {" "}
-                {t("you_will_get")}:{" "}
-                <strong>{Number(expectedIQ).toFixed(2)} IQ</strong>
-              </p>
-              <p className="mb-0">
-                {" "}
-                {t("expected_apr")}:{" "}
-                <strong>{Number(aprDividedByLockPeriod).toFixed(2)} %</strong>
-              </p>
-            </StyledDivContainer>
-          ) : null}
+          <div className="d-flex flex-row justify-content-center p-2">
+            <StyledButton
+              onClick={() => handleYearsInput(0.0833334)}
+              size="sm"
+              variant="light"
+              className="m-1 shadow-sm"
+            >
+              1 month
+            </StyledButton>
+            <StyledButton
+              onClick={() => handleYearsInput(0.25)}
+              size="sm"
+              variant="light"
+              className="m-1 shadow-sm"
+            >
+              3 months
+            </StyledButton>
+            <StyledButton
+              onClick={() => handleYearsInput(0.500001)}
+              size="sm"
+              variant="light"
+              className="m-1 shadow-sm"
+            >
+              6 months
+            </StyledButton>
+          </div>
+
+          <StyledDivContainer className="shadow-sm">
+            <p className="mb-0">
+              {" "}
+              {t("you_will_get")}:{" "}
+              <strong>
+                {expectedIQ ? Number(expectedIQ).toFixed(2) : 0} IQ
+              </strong>
+            </p>
+            <p className="mb-0">
+              {" "}
+              {t("expected_apr")}:{" "}
+              <strong>
+                {aprDividedByLockPeriod
+                  ? Number(aprDividedByLockPeriod).toFixed(2)
+                  : 0}{" "}
+                %
+              </strong>
+            </p>
+          </StyledDivContainer>
         </Form>
       }
     />

--- a/src/components/ui/rewardsCalculatorDialog.js
+++ b/src/components/ui/rewardsCalculatorDialog.js
@@ -60,7 +60,10 @@ const RewardsCalculatorDialog = ({
 
       const aprAcrossLockPeriod = userRewardsPlusInitialLock / inputIQ;
 
-      setAprDividedByLockPeriod((aprAcrossLockPeriod / years) * 100);
+      let percentage = 100;
+      if (years < 1) percentage = (years * 100) / 1;
+
+      setAprDividedByLockPeriod((aprAcrossLockPeriod / years) * percentage);
     }
   }, [inputIQ, years]);
 

--- a/src/components/ui/rewardsCalculatorDialog.js
+++ b/src/components/ui/rewardsCalculatorDialog.js
@@ -122,14 +122,6 @@ const RewardsCalculatorDialog = ({
           />
           <div className="d-flex flex-row justify-content-center p-2">
             <StyledButton
-              onClick={() => handleYearsInput(0.0833334)}
-              size="sm"
-              variant="light"
-              className="m-1 shadow-sm"
-            >
-              1 month
-            </StyledButton>
-            <StyledButton
               onClick={() => handleYearsInput(0.25)}
               size="sm"
               variant="light"
@@ -138,12 +130,20 @@ const RewardsCalculatorDialog = ({
               3 months
             </StyledButton>
             <StyledButton
-              onClick={() => handleYearsInput(0.500001)}
+              onClick={() => handleYearsInput(1)}
               size="sm"
               variant="light"
               className="m-1 shadow-sm"
             >
-              6 months
+              1 year
+            </StyledButton>
+            <StyledButton
+              onClick={() => handleYearsInput(4)}
+              size="sm"
+              variant="light"
+              className="m-1 shadow-sm"
+            >
+              4 years
             </StyledButton>
           </div>
 

--- a/src/components/ui/rewardsCalculatorDialog.js
+++ b/src/components/ui/rewardsCalculatorDialog.js
@@ -66,7 +66,7 @@ const RewardsCalculatorDialog = ({
       const aprAcrossLockPeriod = userRewardsPlusInitialLock / inputIQ;
 
       let percentage = 100;
-      if (years < 1) percentage = (years * 100) / 1;
+      if (years < 1) percentage = years * 100;
 
       setAprDividedByLockPeriod((aprAcrossLockPeriod / years) * percentage);
     }


### PR DESCRIPTION
# Fix rewards calculation for values below 1 year
_It was reported that the  Rewards Calculator was showing invalid APR amounts for periods below 1 year. This PR includes a validation for periods below 1 year, in which it is taken the proportional percentage value for those periods. Minor fixes were also included._
## How should this be tested?
1. `yarn start` or use the preview link provided below
## Notes or observations
@kesar @zer0blockchain can you provide any feedback on this?
## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/7
