### PR TITLE
fix: checkpoint button

### DIFF
--- a/src/features/Lock/lock.js
+++ b/src/features/Lock/lock.js
@@ -286,7 +286,7 @@ const Lock = () => {
         <CardDivContainer className="d-flex flex-row flex-wrap-reverse align-items-center">
           <Stats
             wallet={wallet}
-            lockedAlready={currentHiIQ && currentHiIQ !== 0}
+            lockedAlready={currentHiIQ !== undefined && currentHiIQ !== 0}
           />
           <FormProvider {...methods}>
             <Col className="mb-3">
@@ -402,7 +402,9 @@ const Lock = () => {
                       wallet={wallet}
                       updateParentLockValue={lv => handleSetLockValue(lv)}
                       radioValue={radioValue}
-                      filledAmount={Number(filledAmount).toFixed(2)}
+                      filledAmount={
+                        filledAmount ? Number(filledAmount).toFixed(2) : 0
+                      }
                       currentHIIQ={currentHiIQ}
                       maximumLockableTime={maximumLockableTime}
                     />

--- a/src/features/Lock/stats.js
+++ b/src/features/Lock/stats.js
@@ -81,6 +81,7 @@ const Stats = ({ wallet, lockedAlready }) => {
     await checkpointResult.wait();
 
     setIsCallingCheckpoint(false);
+    if (checkpointResult) setUserIsInitialzed(true);
   };
 
   const getOverlay = (showOverlay, overlayTarget, tooltipText) => (
@@ -338,43 +339,48 @@ const Stats = ({ wallet, lockedAlready }) => {
                         </Button>
                       ) : null}
 
-                      {(lockedAlready &&
-                        earnedRewards !== undefined &&
-                        earnedRewards === 0 &&
-                        wallet.status === "connected") ||
-                      (userIsInitialized !== undefined &&
-                        userIsInitialized === false) ? (
-                        // eslint-disable-next-line react/jsx-indent
-                        <div className="d-flex flex-row justify-content-center align-items-center">
-                          <Button
-                            onClick={handleCallCheckpoint}
-                            size="sm"
-                            className="shadow-sm"
-                            variant="warning"
-                          >
-                            {isCallingCheckpoint
-                              ? `${t("loading")}...`
-                              : t("checkpoint")}
-                          </Button>
-                          <Button
-                            variant="light"
-                            size="sm"
-                            className="ml-2"
-                            ref={checkpointOverlayTarget}
-                            onClick={event => {
-                              event.preventDefault();
-                              setShowCheckpointOverlay(!showCheckpointOverlay);
-                            }}
-                          >
-                            <QuestionCircle />
-                          </Button>
-                          {getOverlay(
-                            showCheckpointOverlay,
-                            checkpointOverlayTarget,
-                            t("needed_to_keep_track")
-                          )}
-                        </div>
-                      ) : null}
+                      {
+                        // (lockedAlready &&
+                        //   earnedRewards !== undefined &&
+                        //   earnedRewards === 0 &&
+                        //   wallet.status === "connected") ||
+                        lockedAlready &&
+                        userIsInitialized !== undefined &&
+                        userIsInitialized === false ? (
+                          // eslint-disable-next-line react/jsx-indent
+                          <div className="d-flex flex-row justify-content-center align-items-center">
+                            <Button
+                              onClick={handleCallCheckpoint}
+                              size="sm"
+                              className="shadow-sm"
+                              variant="warning"
+                            >
+                              {isCallingCheckpoint
+                                ? `${t("loading")}...`
+                                : t("checkpoint")}
+                            </Button>
+                            <Button
+                              variant="light"
+                              size="sm"
+                              className="ml-2"
+                              ref={checkpointOverlayTarget}
+                              onClick={event => {
+                                event.preventDefault();
+                                setShowCheckpointOverlay(
+                                  !showCheckpointOverlay
+                                );
+                              }}
+                            >
+                              <QuestionCircle />
+                            </Button>
+                            {getOverlay(
+                              showCheckpointOverlay,
+                              checkpointOverlayTarget,
+                              t("needed_to_keep_track")
+                            )}
+                          </div>
+                        ) : null
+                      }
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
# Fix checkpoint button not showing
_The checkpoint is now shown after a signing request reject_
## How should this be tested?
1. `yarn start`
## Notes or observations
_@kesar, the checkpoint will appear if the user rejects the signing request before locking the tokens. But it won't when the user increases the amount or the time, because after locking the tokens, the user is initialized in the system, so that verification is not suitable for those scenarios.
I think, one simple solution will be just to enable it and inform when they need to checkpoint, like when they reject the request._
## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/24
