### PR TITLE
Fix/increase unlock time error

### DIFF
--- a/src/features/Lock/lockPeriod.js
+++ b/src/features/Lock/lockPeriod.js
@@ -135,7 +135,7 @@ const LockPeriod = ({
               }}
               onChange={handleOnSliderChange}
               value={lockValue}
-              max={remaining || 209}
+              max={remaining || 208}
               step={1}
             />
           </Col>
@@ -156,7 +156,7 @@ const LockPeriod = ({
                 (radioValue === 1 && (!filledAmount || filledAmount === 0)) ||
                 remaining === 0
               }
-              max={remaining || 209}
+              max={remaining || 208}
               min={0}
               step={1}
               value={lockValue || 0}

--- a/src/features/Lock/lockPeriod.js
+++ b/src/features/Lock/lockPeriod.js
@@ -135,7 +135,7 @@ const LockPeriod = ({
               }}
               onChange={handleOnSliderChange}
               value={lockValue}
-              max={remaining || 208}
+              max={remaining || 209}
               step={1}
             />
           </Col>
@@ -156,7 +156,7 @@ const LockPeriod = ({
                 (radioValue === 1 && (!filledAmount || filledAmount === 0)) ||
                 remaining === 0
               }
-              max={remaining || 208}
+              max={remaining || 209}
               min={0}
               step={1}
               value={lockValue || 0}

--- a/src/utils/EthDataProvider/EthDataProvider.js
+++ b/src/utils/EthDataProvider/EthDataProvider.js
@@ -314,8 +314,10 @@ const getLockedEnd = async wallet => {
 
     const result = await hiIQ.locked__end(wallet.account);
 
+    const date = new Date(Number(result.toString()) * 1000);
+    const userTimezoneOffset = date.getTimezoneOffset() * 60000;
     // eslint-disable-next-line no-underscore-dangle
-    return new Date(parseInt(result._hex, 16) * 1000);
+    return new Date(date.getTime() - userTimezoneOffset);
   }
 
   return false;
@@ -325,17 +327,14 @@ const getMaximumLockableTime = async (wallet, lockEnd) => {
   if (wallet.status === "connected") {
     const provider = new ethers.providers.Web3Provider(wallet.ethereum);
     const block = await provider.getBlock("latest");
-    console.log(new Date(block.timestamp * 1000));
     const max = new Date((block.timestamp + 4 * 365 * 86400) * 1000);
     max.setHours(0);
     max.setMinutes(0);
     max.setSeconds(0);
-    console.log(max);
 
     const diffTime = Math.abs(max - lockEnd);
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
-    console.log(diffDays);
     return diffDays - 1;
   }
   return false;

--- a/src/utils/EthDataProvider/EthDataProvider.js
+++ b/src/utils/EthDataProvider/EthDataProvider.js
@@ -325,11 +325,17 @@ const getMaximumLockableTime = async (wallet, lockEnd) => {
   if (wallet.status === "connected") {
     const provider = new ethers.providers.Web3Provider(wallet.ethereum);
     const block = await provider.getBlock("latest");
+    console.log(new Date(block.timestamp * 1000));
     const max = new Date((block.timestamp + 4 * 365 * 86400) * 1000);
+    max.setHours(0);
+    max.setMinutes(0);
+    max.setSeconds(0);
+    console.log(max);
 
     const diffTime = Math.abs(max - lockEnd);
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
 
+    console.log(diffDays);
     return diffDays - 1;
   }
   return false;


### PR DESCRIPTION
# Fix increase unlock time error
_Substract the timezone offset and set 12:00 AM to the maximum lockable time to avoid the increase unlock time error_
## How should this be tested?
1. `yarn start`
2. Lock some tokens and increase the unlock time
## Linked issues
closes https://github.com/EveripediaNetwork/issues/issues/6
